### PR TITLE
preserve permissions/roles null and false values when snapshotting

### DIFF
--- a/src/commands/permissions.ts
+++ b/src/commands/permissions.ts
@@ -1,5 +1,5 @@
-import { pickBy, identity, uniq, isEqual, omit } from 'lodash-es';
 import { Filter, PermissionItem, RoleItem } from '@directus/sdk';
+import { identity, isEqual, omit, pickBy, uniq } from 'lodash-es';
 import { BaseCommandOptions, DirectusClient } from './common';
 
 export interface PermissionsSnapshotOptions extends BaseCommandOptions {
@@ -65,7 +65,7 @@ export async function snapshotPermissions(
     roles.map(async (role: RoleItem) => {
       const permits = await fetchRemoteRolePermissions(role.id, client);
       return {
-        ...pickBy<RoleItem>(role, identity),
+        ...pickBy(role, (v) => v !== undefined),
         permits,
       };
     }),

--- a/src/commands/permissions.ts
+++ b/src/commands/permissions.ts
@@ -1,5 +1,5 @@
 import { Filter, PermissionItem, RoleItem } from '@directus/sdk';
-import { identity, isEqual, omit, pickBy, uniq } from 'lodash-es';
+import { isEqual, omit, pickBy, uniq } from 'lodash-es';
 import { BaseCommandOptions, DirectusClient } from './common';
 
 export interface PermissionsSnapshotOptions extends BaseCommandOptions {
@@ -30,7 +30,7 @@ async function fetchRemoteRolePermissions(
   }
   return response.data.reduce((acc, { id, collection, action, fields, ...rest }) => {
     const serialized: CustomPermissionItem = {
-      ...pickBy(rest, identity),
+      ...pickBy(rest, (v) => v !== undefined),
       fields: fields?.sort(),
       id: opts?.includeId ? id : undefined,
     };


### PR DESCRIPTION
Currently snapshotting roles/permissions is ignoring all falsy values, which is removing properties set to null/false. Some of these values will default to something other than false/null when running apply, which will cause inconsistency between the 2 environments.
The place where I noticed this was in `app_access`, it is defaulting to true when applying snapshot.